### PR TITLE
Adds getter and setter for Dig FX particleScale

### DIFF
--- a/codechicken/lib/render/EntityDigIconFX.java
+++ b/codechicken/lib/render/EntityDigIconFX.java
@@ -25,6 +25,14 @@ public class EntityDigIconFX extends EntityFX
         return 1;
     }
     
+    public void setScale(float scale) {
+        particleScale = scale;
+    }
+
+    public float getScale() {
+        return particleScale;
+    }
+    
     /**
      * copy pasted from EntityDiggingFX
      */


### PR DESCRIPTION
Allows for one to edit or retrieve the scale of the particle. this is the last remaining factor in multiple particles having exact matching fields.
Targeting layered texture break fx
