### PR TITLE
Accessors for particleMaxAge

### DIFF
--- a/codechicken/lib/render/EntityDigIconFX.java
+++ b/codechicken/lib/render/EntityDigIconFX.java
@@ -33,6 +33,14 @@ public class EntityDigIconFX extends EntityFX
         return particleScale;
     }
     
+    public void setMaxAge(int age){
+        particleMaxAge = age;
+    }
+    
+    public int getMaxAge(){
+        return particleMaxAge;
+    }
+    
     /**
      * copy pasted from EntityDiggingFX
      */


### PR DESCRIPTION
Allows access to the maxAge for "copied" layers to behave for the same duration.
