### PR TITLE
Fix LangUtil.java for 1.7

### DIFF
--- a/codechicken/lib/lang/LangUtil.java
+++ b/codechicken/lib/lang/LangUtil.java
@@ -7,8 +7,8 @@ import java.io.InputStreamReader;
 import java.util.SortedSet;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.Language;
-import net.minecraft.client.resources.Resource;
-import net.minecraft.client.resources.ResourceManager;
+import net.minecraft.client.resources.IResource;
+import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
 
@@ -81,11 +81,11 @@ public class LangUtil
     @SideOnly(Side.CLIENT)
     public LangUtil addLangDir(ResourceLocation dir)
     {
-        ResourceManager resManager = Minecraft.getMinecraft().getResourceManager();
+        IResourceManager resManager = Minecraft.getMinecraft().getResourceManager();
         for(Language lang : (SortedSet<Language>)Minecraft.getMinecraft().getLanguageManager().getLanguages())
         {
             String langID = lang.getLanguageCode();
-            Resource langRes;
+            IResource langRes;
             try
             {
                 langRes = resManager.getResource(new ResourceLocation(dir.getResourceDomain(), dir.getResourcePath()+'/'+langID+".lang"));


### PR DESCRIPTION
Just a quick tweak for 1.7 preparation: Resource and ResourceManager now have to be IResource and IResourceManager, respectively.
