### PR TITLE
Light attribute should not depend on colour

### DIFF
--- a/src/codechicken/lib/render/CCRenderState.java
+++ b/src/codechicken/lib/render/CCRenderState.java
@@ -190,7 +190,7 @@ public class CCRenderState
 
         @Override
         public boolean load() {
-            if(!computeLighting || !hasColour || !model.hasAttribute(this))
+            if(!computeLighting || !useColour || !model.hasAttribute(this))
                 return false;
 
             colourRef = model.getAttributes(this);


### PR DESCRIPTION
Light attribute makes sure that we have color, but at the time of check, hasColour is false, because nothing has operated yet. We want to check the context flag instead. (We could just not check this color flag at all, and leave the two actually 'separate')
