### PR TITLE
Set ItemStack in the IInventory again after modifiing it.

### DIFF
--- a/src/codechicken/lib/inventory/InventoryUtils.java
+++ b/src/codechicken/lib/inventory/InventoryUtils.java
@@ -50,6 +50,8 @@ public class InventoryUtils
             ItemStack itemstack1 = item.splitStack(size);
             if (item.stackSize == 0)
                 inv.setInventorySlotContents(slot, null);
+            else
+                inv.setInventorySlotContents(slot, item);
 
             inv.markDirty();
             return itemstack1;


### PR DESCRIPTION
This avoids dupe bugs when the returned ItemStack is not part of the actual IInventory implementation.

When for some reason the Implementation for the IInventory doesn't return the internal saved ItemStack, either because it is a copy or because no ItemStacks are used internaly, modifying the size of the ItemStack is not enough to modify the amount of the Item saved in the IInventory.
By setting the ItemStack inside the Inventory again this bug can be avoided.

(This causes item dupes between Translocators and Logistics Pipes Crafting Table)
