### PR TITLE
Bump forge version and mappings.

### DIFF
--- a/build/build.gradle
+++ b/build/build.gradle
@@ -36,7 +36,7 @@ println  config.minecraft_version + "-" + config.forge_version
 // Setup the forge minecraft plugin data. Specify the preferred forge/minecraft version here
 minecraft {
     version = config.minecraft_version + "-" + config.forge_version
-    mappings = "snapshot_nodoc_20141230"
+    mappings = "snapshot_nodoc_20150404"
 }
 
 sourceSets {

--- a/build/build.properties
+++ b/build/build.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.8
-forge_version=11.14.0.1280-1.8
+forge_version=11.14.1.1353
 mod_version=1.1.2

--- a/src/codechicken/lib/inventory/InventoryCopy.java
+++ b/src/codechicken/lib/inventory/InventoryCopy.java
@@ -112,7 +112,7 @@ public class InventoryCopy implements IInventory
     public void clear() {}
 
     @Override
-    public String getName() {
+    public String getCommandSenderName() {
         return "copy";
     }
 
@@ -123,6 +123,6 @@ public class InventoryCopy implements IInventory
 
     @Override
     public IChatComponent getDisplayName() {
-        return new ChatComponentText(getName());
+        return new ChatComponentText(getCommandSenderName());
     }
 }

--- a/src/codechicken/lib/inventory/InventoryNBT.java
+++ b/src/codechicken/lib/inventory/InventoryNBT.java
@@ -103,7 +103,7 @@ public class InventoryNBT implements IInventory
     }
 
     @Override
-    public String getName() {
+    public String getCommandSenderName() {
         return "NBT";
     }
 
@@ -114,6 +114,6 @@ public class InventoryNBT implements IInventory
 
     @Override
     public IChatComponent getDisplayName() {
-        return new ChatComponentText(getName());
+        return new ChatComponentText(getCommandSenderName());
     }
 }

--- a/src/codechicken/lib/inventory/InventorySimple.java
+++ b/src/codechicken/lib/inventory/InventorySimple.java
@@ -116,7 +116,7 @@ public class InventorySimple implements IInventory
     public void clear() {}
 
     @Override
-    public String getName() {
+    public String getCommandSenderName() {
         return "name";
     }
 
@@ -127,6 +127,6 @@ public class InventorySimple implements IInventory
 
     @Override
     public IChatComponent getDisplayName() {
-        return new ChatComponentText(getName());
+        return new ChatComponentText(getCommandSenderName());
     }
 }


### PR DESCRIPTION
progwml6's natura is running a newer mappings and forge version then NEI/CCC/CCL is and because of this, NEI crashes due to not finding methods that are renamed in the newer mappings.