### PR TITLE
Prevent ColourMultiplier from setting hasColour flag

### DIFF
--- a/src/codechicken/lib/render/ColourMultiplier.java
+++ b/src/codechicken/lib/render/ColourMultiplier.java
@@ -21,7 +21,7 @@ public class ColourMultiplier implements CCRenderState.IVertexOperation
     @Override
     public boolean load() {
         if(colour == -1) {
-            CCRenderState.setColour(-1);
+            CCRenderState.hasColour = false;
             return false;
         }
 

--- a/src/codechicken/lib/render/ColourMultiplier.java
+++ b/src/codechicken/lib/render/ColourMultiplier.java
@@ -20,10 +20,7 @@ public class ColourMultiplier implements CCRenderState.IVertexOperation
 
     @Override
     public boolean load() {
-        if(colour == -1) {
-            CCRenderState.hasColour = false;
-            return false;
-        }
+        if(colour == -1) return false;
 
         CCRenderState.pipeline.addDependency(CCRenderState.colourAttrib);
         return true;


### PR DESCRIPTION
Tested with ProjectRed wires and microblocks with no noticeable side effects.  It will come down to whether or not setting a -1 colour would always have the same effect as setting no colour at all.